### PR TITLE
Rename terminus to tabby and update deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hype Theme
 
-#### For the Terminus terminal
+#### For the Tabby terminal
 
 This is a simple theme that mimicks the Hyper terminal. You can use this plugin as a base to build a theme of your own!
 
@@ -10,9 +10,9 @@ This is a simple theme that mimicks the Hyper terminal. You can use this plugin 
 
 ## Hacking
 
-Terminus layout is based on Bootstrap 4, so the easiest way is to base the theme on Bootstrap as well.
+Tabby layout is based on Bootstrap 4, so the easiest way is to base the theme on Bootstrap as well.
 
-The styles are located in the [theme.scss](https://github.com/Eugeny/terminus-theme-hype/blob/master/src/theme.scss) file. It starts with a few Bootstrap variable overrides, then Bootstrap itself is included, and then there are some more direct style overrides.
+The styles are located in the [theme.scss](https://github.com/Eugeny/tabby-theme-hype/blob/master/src/theme.scss) file. It starts with a few Bootstrap variable overrides, then Bootstrap itself is included, and then there are some more direct style overrides.
 
 Adjust the theme name and terminal background color in [index.ts](https://github.com/Eugeny/terminus-theme-hype/blob/master/src/index.ts)
 
@@ -30,12 +30,12 @@ npm run watch
 
 and your changes to the styles will be rebuilt automatically.
 
-Meanwhile, start Terminus with this plugin included:
+Meanwhile, start Tabby with this plugin included:
 
 ```
-TERMINUS_PLUGINS=$(pwd) terminus --debug
+TABBY_PLUGINS=$(pwd) tabby --debug
 ```
 
-While Terminus is running, you can reload the plugins by pressing `Ctrl-R` (`Cmd-R` on macOS).
+While Tabby is running, you can reload the plugins by pressing `Ctrl-R` (`Cmd-R` on macOS).
 
 When done, publish your theme to NPM!

--- a/package.json
+++ b/package.json
@@ -15,26 +15,27 @@
   "author": "Eugene Pankov",
   "license": "MIT",
   "peerDependencies": {
-    "@angular/core": "4.0.1",
-    "terminus-core": "*"
+    "@angular/core": "^9.1.11",
+    "tabby-core": "^1.0.187-nightly.1"
   },
   "devDependencies": {
-    "@angular/common": "^4.1.3",
-    "@angular/core": "^4.1.3",
-    "@angular/forms": "^4.1.3",
+    "@angular/common": "^9.1.11",
+    "@angular/core": "^9.1.11",
+    "@angular/forms": "^9.1.11",
     "@types/electron": "^1.6.10",
-    "@types/webpack-env": "^1.13.0",
-    "awesome-typescript-loader": "3.1.2",
-    "bootstrap": "4.0.0-alpha.6",
-    "css-loader": "0.26.1",
-    "node-sass": "^4.5.0",
-    "raw-loader": "0.5.1",
-    "rxjs": "^5.4.0",
-    "sass-loader": "^6.0.3",
-    "terminus-core": "0.0.2",
-    "to-string-loader": "^1.1.5",
-    "typescript": "~2.1.0",
-    "webpack": "2.3.3"
+    "@types/webpack-env": "^1.18.0",
+    "ts-loader": "^9.4.2",
+    "bootstrap": "^4.0.0",
+    "css-loader": "^6.7.3",
+    "node-sass": "^8.0.0",
+    "raw-loader": "^4.0.2",
+    "rxjs": "^6.5.5",
+    "sass-loader": "^13.2.0",
+    "tabby-core": "^1.0.187-nightly.1",
+    "to-string-loader": "^1.2.0",
+    "typescript": "^4.9.4",
+    "webpack": "^5.75.0",
+    "webpack-cli": "^5.0.1"
   },
   "repository": "eugeny/terminus-theme-hype"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { NgModule, Injectable } from '@angular/core'
-import { Theme } from 'terminus-core'
+import { Theme } from 'tabby-core'
 
 @Injectable()
 class HypeTheme extends Theme {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,13 +16,11 @@ module.exports = {
     extensions: ['.ts', '.js'],
   },
   module: {
-    loaders: [
+    rules: [
       {
-        test: /\.ts$/,
-        loader: 'awesome-typescript-loader',
-        options: {
-          configFileName: path.resolve(__dirname, 'tsconfig.json'),
-        }
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
       },
       { test: /\.scss$/, use: ['to-string-loader', 'css-loader', 'sass-loader'] },
     ]
@@ -30,6 +28,7 @@ module.exports = {
   externals: [
     /^@angular/,
     /^@ng-bootstrap/,
-    /^terminus-/,
-  ]
+    /^tabby-/,
+  ],
+  mode: 'development'
 }


### PR DESCRIPTION
This PR updates the project to use the new name "Tabby" instead of "Terminus" and updates the dependencies.

_This code was tested with node version 19.4._